### PR TITLE
Add TrackingWheelLocalizer

### DIFF
--- a/include/VOSS/api.hpp
+++ b/include/VOSS/api.hpp
@@ -22,6 +22,8 @@
 #include "localizer/GPSLocalizer.hpp"
 #include "localizer/IMELocalizer.hpp"
 #include "localizer/IMELocalizerBuilder.hpp"
+#include "localizer/TrackingWheelLocalizer.hpp"
+#include "localizer/TrackingWheelLocalizerBuilder.hpp"
 
 #include "selector/Selector.hpp"
 

--- a/include/VOSS/chassis/AbstractChassis.hpp
+++ b/include/VOSS/chassis/AbstractChassis.hpp
@@ -21,7 +21,6 @@ class AbstractChassis {
     bool task_running = false;
     pros::motor_brake_mode_e brakeMode;
 
-
     void move_task(controller_ptr controller, double max, voss::Flags flags,
                    double exitTime);
 

--- a/include/VOSS/localizer/ADITrackingWheel.hpp
+++ b/include/VOSS/localizer/ADITrackingWheel.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
-#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include "pros/adi.hpp"
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include <memory>
 
 namespace voss::localizer {
 
 class ADITrackingWheel : public AbstractTrackingWheel {
-private:
+  private:
     std::unique_ptr<pros::adi::Encoder> encoder;
-protected:
+
+  protected:
     double get_raw_position() override;
-public:
+
+  public:
     ADITrackingWheel(int adi_port);
     ADITrackingWheel(int smart_port, int adi_port);
     void reset() override;
 };
 
-}
+} // namespace voss::localizer

--- a/include/VOSS/localizer/ADITrackingWheel.hpp
+++ b/include/VOSS/localizer/ADITrackingWheel.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
+#include "pros/adi.hpp"
+#include <memory>
+
+namespace voss::localizer {
+
+class ADITrackingWheel : public AbstractTrackingWheel {
+private:
+    std::unique_ptr<pros::adi::Encoder> encoder;
+protected:
+    double get_raw_position() override;
+public:
+    ADITrackingWheel(int adi_port);
+    ADITrackingWheel(int smart_port, int adi_port);
+    void reset() override;
+};
+
+}

--- a/include/VOSS/localizer/AbstractTrackingWheel.hpp
+++ b/include/VOSS/localizer/AbstractTrackingWheel.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <atomic>
+
+namespace voss::localizer {
+
+class AbstractTrackingWheel {
+protected:
+    AbstractTrackingWheel();
+    std::atomic<double> tpi;
+    virtual double get_raw_position() = 0;
+public:
+    double get_dist_travelled();
+    void set_tpi(double new_tpi);
+    virtual void reset() = 0;
+};
+
+}

--- a/include/VOSS/localizer/AbstractTrackingWheel.hpp
+++ b/include/VOSS/localizer/AbstractTrackingWheel.hpp
@@ -5,14 +5,15 @@
 namespace voss::localizer {
 
 class AbstractTrackingWheel {
-protected:
+  protected:
     AbstractTrackingWheel();
     std::atomic<double> tpi;
     virtual double get_raw_position() = 0;
-public:
+
+  public:
     double get_dist_travelled();
     void set_tpi(double new_tpi);
     virtual void reset() = 0;
 };
 
-}
+} // namespace voss::localizer

--- a/include/VOSS/localizer/IMETrackingWheel.hpp
+++ b/include/VOSS/localizer/IMETrackingWheel.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
-#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include "pros/motors.hpp"
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include <memory>
 
 namespace voss::localizer {
 
 class IMETrackingWheel : public AbstractTrackingWheel {
-private:
+  private:
     std::unique_ptr<pros::v5::Motor> encoder;
-protected:
+
+  protected:
     double get_raw_position() override;
-public:
+
+  public:
     IMETrackingWheel(int port);
     void reset() override;
 };
 
-}
+} // namespace voss::localizer

--- a/include/VOSS/localizer/IMETrackingWheel.hpp
+++ b/include/VOSS/localizer/IMETrackingWheel.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
+#include "pros/motors.hpp"
+#include <memory>
+
+namespace voss::localizer {
+
+class IMETrackingWheel : public AbstractTrackingWheel {
+private:
+    std::unique_ptr<pros::v5::Motor> encoder;
+protected:
+    double get_raw_position() override;
+public:
+    IMETrackingWheel(int port);
+    void reset() override;
+};
+
+}

--- a/include/VOSS/localizer/RotationTrackingWheel.hpp
+++ b/include/VOSS/localizer/RotationTrackingWheel.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
-#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include "pros/rotation.hpp"
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
 #include <memory>
 
 namespace voss::localizer {
 
 class RotationTrackingWheel : public AbstractTrackingWheel {
-private:
+  private:
     std::unique_ptr<pros::v5::Rotation> encoder;
-protected:
+
+  protected:
     double get_raw_position() override;
-public:
+
+  public:
     RotationTrackingWheel(int port);
     void reset() override;
 };
 
-}
+} // namespace voss::localizer

--- a/include/VOSS/localizer/RotationTrackingWheel.hpp
+++ b/include/VOSS/localizer/RotationTrackingWheel.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
+#include "pros/rotation.hpp"
+#include <memory>
+
+namespace voss::localizer {
+
+class RotationTrackingWheel : public AbstractTrackingWheel {
+private:
+    std::unique_ptr<pros::v5::Rotation> encoder;
+protected:
+    double get_raw_position() override;
+public:
+    RotationTrackingWheel(int port);
+    void reset() override;
+};
+
+}

--- a/include/VOSS/localizer/TrackingWheelLocalizer.hpp
+++ b/include/VOSS/localizer/TrackingWheelLocalizer.hpp
@@ -1,24 +1,29 @@
 #pragma once
 
+#include "pros/imu.hpp"
 #include "VOSS/localizer/AbstractLocalizer.hpp"
 #include "VOSS/localizer/AbstractTrackingWheel.hpp"
-#include "pros/imu.hpp"
 #include <atomic>
 #include <memory>
 
 namespace voss::localizer {
 
 class TrackingWheelLocalizer : public AbstractLocalizer {
-protected:
+  protected:
     std::atomic<double> prev_left_pos, prev_right_pos, prev_middle_pos;
     AtomicPose prev_pose;
 
     std::atomic<double> left_right_dist, middle_dist;
-    std::unique_ptr<AbstractTrackingWheel> left_tracking_wheel, right_tracking_wheel, middle_tracking_wheel;
+    std::unique_ptr<AbstractTrackingWheel> left_tracking_wheel,
+        right_tracking_wheel, middle_tracking_wheel;
     std::unique_ptr<pros::IMU> imu;
-public:
-    TrackingWheelLocalizer(std::unique_ptr<AbstractTrackingWheel> left, std::unique_ptr<AbstractTrackingWheel> right,
-        std::unique_ptr<AbstractTrackingWheel> middle, std::unique_ptr<pros::IMU> imu, double left_right_dist, double middle_dist);
+
+  public:
+    TrackingWheelLocalizer(std::unique_ptr<AbstractTrackingWheel> left,
+                           std::unique_ptr<AbstractTrackingWheel> right,
+                           std::unique_ptr<AbstractTrackingWheel> middle,
+                           std::unique_ptr<pros::IMU> imu,
+                           double left_right_dist, double middle_dist);
     void update() override;
     void calibrate() override;
     void set_pose(Pose pose);
@@ -26,4 +31,4 @@ public:
     friend class TrackingWheelLocalizerBuilder;
 };
 
-}
+} // namespace voss::localizer

--- a/include/VOSS/localizer/TrackingWheelLocalizer.hpp
+++ b/include/VOSS/localizer/TrackingWheelLocalizer.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "VOSS/localizer/AbstractLocalizer.hpp"
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
+#include "pros/imu.hpp"
+#include <atomic>
+#include <memory>
+
+namespace voss::localizer {
+
+class TrackingWheelLocalizer : public AbstractLocalizer {
+protected:
+    std::atomic<double> prev_left_pos, prev_right_pos, prev_middle_pos;
+    AtomicPose prev_pose;
+
+    std::atomic<double> left_right_dist, middle_dist;
+    std::unique_ptr<AbstractTrackingWheel> left_tracking_wheel, right_tracking_wheel, middle_tracking_wheel;
+    std::unique_ptr<pros::IMU> imu;
+public:
+    TrackingWheelLocalizer(std::unique_ptr<AbstractTrackingWheel> left, std::unique_ptr<AbstractTrackingWheel> right,
+        std::unique_ptr<AbstractTrackingWheel> middle, std::unique_ptr<pros::IMU> imu, double left_right_dist, double middle_dist);
+    void update() override;
+    void calibrate() override;
+    void set_pose(Pose pose);
+
+    friend class TrackingWheelLocalizerBuilder;
+};
+
+}

--- a/include/VOSS/localizer/TrackingWheelLocalizerBuilder.hpp
+++ b/include/VOSS/localizer/TrackingWheelLocalizerBuilder.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "VOSS/localizer/TrackingWheelLocalizer.hpp"
+
+namespace voss::localizer {
+
+class TrackingWheelLocalizerBuilder {
+private:
+    double left_right_dist;
+    double middle_dist;
+    std::unique_ptr<AbstractTrackingWheel> left_tracking_wheel;
+    std::unique_ptr<AbstractTrackingWheel> right_tracking_wheel;
+    std::unique_ptr<AbstractTrackingWheel> middle_tracking_wheel;
+    std::unique_ptr<pros::IMU> imu;
+public:
+    TrackingWheelLocalizerBuilder();
+
+    static TrackingWheelLocalizerBuilder new_builder();
+
+    TrackingWheelLocalizerBuilder& with_left_encoder(int adi_port);
+    TrackingWheelLocalizerBuilder& with_left_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_left_rotation(int port);
+    TrackingWheelLocalizerBuilder& with_left_motor(int port);
+    TrackingWheelLocalizerBuilder& with_right_encoder(int adi_port);
+    TrackingWheelLocalizerBuilder& with_right_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_right_rotation(int port);
+    TrackingWheelLocalizerBuilder& with_right_motor(int port);
+    TrackingWheelLocalizerBuilder& with_middle_encoder(int adi_port);
+    TrackingWheelLocalizerBuilder& with_middle_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_middle_rotation(int port);
+    TrackingWheelLocalizerBuilder& with_middle_motor(int port);
+    TrackingWheelLocalizerBuilder& with_left_right_tpi(double tpi);
+    TrackingWheelLocalizerBuilder& with_middle_tpi(double tpi);
+    TrackingWheelLocalizerBuilder& with_track_width(double track_width);
+    TrackingWheelLocalizerBuilder& with_middle_dist(double middle_dist);
+    TrackingWheelLocalizerBuilder& with_imu(int port);
+
+    std::shared_ptr<TrackingWheelLocalizer> build();
+};
+
+}

--- a/include/VOSS/localizer/TrackingWheelLocalizerBuilder.hpp
+++ b/include/VOSS/localizer/TrackingWheelLocalizerBuilder.hpp
@@ -5,28 +5,32 @@
 namespace voss::localizer {
 
 class TrackingWheelLocalizerBuilder {
-private:
+  private:
     double left_right_dist;
     double middle_dist;
     std::unique_ptr<AbstractTrackingWheel> left_tracking_wheel;
     std::unique_ptr<AbstractTrackingWheel> right_tracking_wheel;
     std::unique_ptr<AbstractTrackingWheel> middle_tracking_wheel;
     std::unique_ptr<pros::IMU> imu;
-public:
+
+  public:
     TrackingWheelLocalizerBuilder();
 
     static TrackingWheelLocalizerBuilder new_builder();
 
     TrackingWheelLocalizerBuilder& with_left_encoder(int adi_port);
-    TrackingWheelLocalizerBuilder& with_left_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_left_encoder(int smart_port,
+                                                     int adi_port);
     TrackingWheelLocalizerBuilder& with_left_rotation(int port);
     TrackingWheelLocalizerBuilder& with_left_motor(int port);
     TrackingWheelLocalizerBuilder& with_right_encoder(int adi_port);
-    TrackingWheelLocalizerBuilder& with_right_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_right_encoder(int smart_port,
+                                                      int adi_port);
     TrackingWheelLocalizerBuilder& with_right_rotation(int port);
     TrackingWheelLocalizerBuilder& with_right_motor(int port);
     TrackingWheelLocalizerBuilder& with_middle_encoder(int adi_port);
-    TrackingWheelLocalizerBuilder& with_middle_encoder(int smart_port, int adi_port);
+    TrackingWheelLocalizerBuilder& with_middle_encoder(int smart_port,
+                                                       int adi_port);
     TrackingWheelLocalizerBuilder& with_middle_rotation(int port);
     TrackingWheelLocalizerBuilder& with_middle_motor(int port);
     TrackingWheelLocalizerBuilder& with_left_right_tpi(double tpi);
@@ -38,4 +42,4 @@ public:
     std::shared_ptr<TrackingWheelLocalizer> build();
 };
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/chassis/DiffChassis.cpp
+++ b/src/VOSS/chassis/DiffChassis.cpp
@@ -61,7 +61,7 @@ bool DiffChassis::execute(DiffChassisCommand cmd, double max) {
                 this->set_brake_mode(this->brakeMode);
                 this->left_motors->brake();
                 this->right_motors->brake();
-              
+
                 return true;
             },
             [this, max](diff_commands::Voltages& v) -> bool {

--- a/src/VOSS/localizer/ADITrackingWheel.cpp
+++ b/src/VOSS/localizer/ADITrackingWheel.cpp
@@ -3,11 +3,15 @@
 namespace voss::localizer {
 
 ADITrackingWheel::ADITrackingWheel(int adi_port) : AbstractTrackingWheel() {
-    this->encoder = std::make_unique<pros::adi::Encoder>(abs(adi_port), abs(adi_port) + 1, adi_port < 0);
+    this->encoder = std::make_unique<pros::adi::Encoder>(
+        abs(adi_port), abs(adi_port) + 1, adi_port < 0);
 }
 
-ADITrackingWheel::ADITrackingWheel(int smart_port, int adi_port) : AbstractTrackingWheel() {
-    this->encoder = std::make_unique<pros::adi::Encoder>(std::make_tuple(smart_port, abs(adi_port), abs(adi_port) + 1), adi_port < 0);
+ADITrackingWheel::ADITrackingWheel(int smart_port, int adi_port)
+    : AbstractTrackingWheel() {
+    this->encoder = std::make_unique<pros::adi::Encoder>(
+        std::make_tuple(smart_port, abs(adi_port), abs(adi_port) + 1),
+        adi_port < 0);
 }
 
 double ADITrackingWheel::get_raw_position() {
@@ -18,4 +22,4 @@ void ADITrackingWheel::reset() {
     this->encoder->reset();
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/ADITrackingWheel.cpp
+++ b/src/VOSS/localizer/ADITrackingWheel.cpp
@@ -1,0 +1,21 @@
+#include "VOSS/localizer/ADITrackingWheel.hpp"
+
+namespace voss::localizer {
+
+ADITrackingWheel::ADITrackingWheel(int adi_port) : AbstractTrackingWheel() {
+    this->encoder = std::make_unique<pros::adi::Encoder>(abs(adi_port), abs(adi_port) + 1, adi_port < 0);
+}
+
+ADITrackingWheel::ADITrackingWheel(int smart_port, int adi_port) : AbstractTrackingWheel() {
+    this->encoder = std::make_unique<pros::adi::Encoder>(std::make_tuple(smart_port, abs(adi_port), abs(adi_port) + 1), adi_port < 0);
+}
+
+double ADITrackingWheel::get_raw_position() {
+    return this->encoder->get_value();
+}
+
+void ADITrackingWheel::reset() {
+    this->encoder->reset();
+}
+
+}

--- a/src/VOSS/localizer/AbstractLocalizer.cpp
+++ b/src/VOSS/localizer/AbstractLocalizer.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/localizer/AbstractLocalizer.hpp"
+#include "VOSS/utils/angle.hpp"
 #include <cmath>
 
 namespace voss::localizer {
@@ -22,7 +23,7 @@ void AbstractLocalizer::begin_localization() {
 
 void AbstractLocalizer::set_pose(Pose pose) {
     std::unique_lock<pros::Mutex> lock(this->mtx);
-    this->pose = pose;
+    this->pose = {pose.x, pose.y, to_radians(pose.theta)};
 }
 
 Pose AbstractLocalizer::get_pose() {

--- a/src/VOSS/localizer/AbstractTrackingWheel.cpp
+++ b/src/VOSS/localizer/AbstractTrackingWheel.cpp
@@ -3,7 +3,6 @@
 namespace voss::localizer {
 
 AbstractTrackingWheel::AbstractTrackingWheel() {
-
 }
 
 double AbstractTrackingWheel::get_dist_travelled() {
@@ -14,4 +13,4 @@ void AbstractTrackingWheel::set_tpi(double new_tpi) {
     this->tpi = new_tpi;
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/AbstractTrackingWheel.cpp
+++ b/src/VOSS/localizer/AbstractTrackingWheel.cpp
@@ -1,0 +1,17 @@
+#include "VOSS/localizer/AbstractTrackingWheel.hpp"
+
+namespace voss::localizer {
+
+AbstractTrackingWheel::AbstractTrackingWheel() {
+
+}
+
+double AbstractTrackingWheel::get_dist_travelled() {
+    return this->get_raw_position() / this->tpi;
+}
+
+void AbstractTrackingWheel::set_tpi(double new_tpi) {
+    this->tpi = new_tpi;
+}
+
+}

--- a/src/VOSS/localizer/IMETrackingWheel.cpp
+++ b/src/VOSS/localizer/IMETrackingWheel.cpp
@@ -14,4 +14,4 @@ void IMETrackingWheel::reset() {
     this->encoder->tare_position();
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/IMETrackingWheel.cpp
+++ b/src/VOSS/localizer/IMETrackingWheel.cpp
@@ -1,0 +1,17 @@
+#include "VOSS/localizer/IMETrackingWheel.hpp"
+
+namespace voss::localizer {
+
+IMETrackingWheel::IMETrackingWheel(int port) : AbstractTrackingWheel() {
+    this->encoder = std::make_unique<pros::v5::Motor>(port);
+}
+
+double IMETrackingWheel::get_raw_position() {
+    return this->encoder->get_position();
+}
+
+void IMETrackingWheel::reset() {
+    this->encoder->tare_position();
+}
+
+}

--- a/src/VOSS/localizer/RotationTrackingWheel.cpp
+++ b/src/VOSS/localizer/RotationTrackingWheel.cpp
@@ -1,0 +1,17 @@
+#include "VOSS/localizer/RotationTrackingWheel.hpp"
+
+namespace voss::localizer {
+
+RotationTrackingWheel::RotationTrackingWheel(int port) : AbstractTrackingWheel() {
+    this->encoder = std::make_unique<pros::v5::Rotation>(port);
+}
+
+double RotationTrackingWheel::get_raw_position() {
+    return this->encoder->get_position();
+}
+
+void RotationTrackingWheel::reset() {
+    this->encoder->reset_position();
+}
+
+}

--- a/src/VOSS/localizer/RotationTrackingWheel.cpp
+++ b/src/VOSS/localizer/RotationTrackingWheel.cpp
@@ -2,7 +2,8 @@
 
 namespace voss::localizer {
 
-RotationTrackingWheel::RotationTrackingWheel(int port) : AbstractTrackingWheel() {
+RotationTrackingWheel::RotationTrackingWheel(int port)
+    : AbstractTrackingWheel() {
     this->encoder = std::make_unique<pros::v5::Rotation>(port);
 }
 
@@ -14,4 +15,4 @@ void RotationTrackingWheel::reset() {
     this->encoder->reset_position();
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/TrackingWheelLocalizer.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizer.cpp
@@ -1,0 +1,83 @@
+#include "VOSS/localizer/TrackingWheelLocalizer.hpp"
+#include "VOSS/utils/angle.hpp"
+
+namespace voss::localizer {
+
+TrackingWheelLocalizer::TrackingWheelLocalizer(std::unique_ptr<AbstractTrackingWheel> left, std::unique_ptr<AbstractTrackingWheel> right,
+    std::unique_ptr<AbstractTrackingWheel> middle, std::unique_ptr<pros::IMU> imu, double left_right_dist, double middle_dist)
+    : AbstractLocalizer(), left_tracking_wheel(std::move(left)), right_tracking_wheel(std::move(right)), middle_tracking_wheel(std::move(middle)),
+    imu(std::move(imu)), left_right_dist(left_right_dist), middle_dist(middle_dist), prev_left_pos(0.0), prev_right_pos(0.0), prev_middle_pos(0.0) {
+
+}
+
+void TrackingWheelLocalizer::update() {
+    double delta_left = 0.0;
+    double delta_right = 0.0;
+    double delta_middle = 0.0;
+    double delta_angle = 0.0;
+
+    if (left_tracking_wheel) {
+        delta_left = left_tracking_wheel->get_dist_travelled() - prev_left_pos;
+    }
+    if (right_tracking_wheel) {
+        delta_right = right_tracking_wheel->get_dist_travelled() - prev_right_pos;
+    }
+    if (middle_tracking_wheel) {
+        delta_middle = middle_tracking_wheel->get_dist_travelled() - prev_middle_pos;
+    }
+    if (imu) {
+        pose.theta = -to_radians(imu->get_rotation());
+        delta_angle = pose.theta - prev_pose.theta;
+    } else {
+        delta_angle = (delta_right - delta_left) / (2 * left_right_dist);
+        pose.theta += delta_angle;
+    }
+
+    prev_left_pos += delta_left;
+    prev_right_pos += delta_right;
+    prev_middle_pos += delta_middle;
+    prev_pose = pose;
+
+    double local_x;
+    double local_y;
+
+    if (delta_angle) {
+        double i = sin(delta_angle / 2.0) * 2.0;
+        local_x = (delta_right / delta_angle - left_right_dist) * i;
+        local_y = (delta_middle / delta_angle + middle_dist) * i;
+    } else {
+        local_x = delta_right;
+        local_y = delta_middle;
+    }
+
+    double p = this->pose.theta - delta_angle / 2.0; // global angle
+
+    // convert to absolute displacement
+    this->pose.x += cos(p) * local_x - sin(p) * local_y;
+    this->pose.y += sin(p) * local_x + cos(p) * local_y;
+}
+
+void TrackingWheelLocalizer::calibrate() {
+    if (left_tracking_wheel) {
+        left_tracking_wheel->reset();
+    }
+    if (right_tracking_wheel) {
+        right_tracking_wheel->reset();
+    }
+    if (middle_tracking_wheel) {
+        middle_tracking_wheel->reset();
+    }
+    if (imu) {
+        imu->reset(true);
+    }
+    this->pose = {0.0, 0.0, 0.0};
+}
+
+void TrackingWheelLocalizer::set_pose(Pose pose) {
+    this->AbstractLocalizer::set_pose(pose);
+    if (this->imu) {
+        this->imu->set_rotation(-pose.theta);
+    }
+}
+
+}

--- a/src/VOSS/localizer/TrackingWheelLocalizer.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizer.cpp
@@ -43,7 +43,11 @@ void TrackingWheelLocalizer::update() {
 
     if (delta_angle) {
         double i = sin(delta_angle / 2.0) * 2.0;
-        local_x = (delta_right / delta_angle - left_right_dist) * i;
+        if (right_tracking_wheel) {
+            local_x = (delta_right / delta_angle - left_right_dist) * i;
+        } else if (left_tracking_wheel) {
+            local_x = (delta_left / delta_angle + left_right_dist) * i;
+        }
         local_y = (delta_middle / delta_angle + middle_dist) * i;
     } else {
         local_x = delta_right;
@@ -75,6 +79,7 @@ void TrackingWheelLocalizer::calibrate() {
 
 void TrackingWheelLocalizer::set_pose(Pose pose) {
     this->AbstractLocalizer::set_pose(pose);
+    this->prev_pose = this->pose;
     if (this->imu) {
         this->imu->set_rotation(-pose.theta);
     }

--- a/src/VOSS/localizer/TrackingWheelLocalizer.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizer.cpp
@@ -3,11 +3,16 @@
 
 namespace voss::localizer {
 
-TrackingWheelLocalizer::TrackingWheelLocalizer(std::unique_ptr<AbstractTrackingWheel> left, std::unique_ptr<AbstractTrackingWheel> right,
-    std::unique_ptr<AbstractTrackingWheel> middle, std::unique_ptr<pros::IMU> imu, double left_right_dist, double middle_dist)
-    : AbstractLocalizer(), left_tracking_wheel(std::move(left)), right_tracking_wheel(std::move(right)), middle_tracking_wheel(std::move(middle)),
-    imu(std::move(imu)), left_right_dist(left_right_dist), middle_dist(middle_dist), prev_left_pos(0.0), prev_right_pos(0.0), prev_middle_pos(0.0) {
-
+TrackingWheelLocalizer::TrackingWheelLocalizer(
+    std::unique_ptr<AbstractTrackingWheel> left,
+    std::unique_ptr<AbstractTrackingWheel> right,
+    std::unique_ptr<AbstractTrackingWheel> middle,
+    std::unique_ptr<pros::IMU> imu, double left_right_dist, double middle_dist)
+    : AbstractLocalizer(), left_tracking_wheel(std::move(left)),
+      right_tracking_wheel(std::move(right)),
+      middle_tracking_wheel(std::move(middle)), imu(std::move(imu)),
+      left_right_dist(left_right_dist), middle_dist(middle_dist),
+      prev_left_pos(0.0), prev_right_pos(0.0), prev_middle_pos(0.0) {
 }
 
 void TrackingWheelLocalizer::update() {
@@ -20,10 +25,12 @@ void TrackingWheelLocalizer::update() {
         delta_left = left_tracking_wheel->get_dist_travelled() - prev_left_pos;
     }
     if (right_tracking_wheel) {
-        delta_right = right_tracking_wheel->get_dist_travelled() - prev_right_pos;
+        delta_right =
+            right_tracking_wheel->get_dist_travelled() - prev_right_pos;
     }
     if (middle_tracking_wheel) {
-        delta_middle = middle_tracking_wheel->get_dist_travelled() - prev_middle_pos;
+        delta_middle =
+            middle_tracking_wheel->get_dist_travelled() - prev_middle_pos;
     }
     if (imu) {
         pose.theta = -to_radians(imu->get_rotation());
@@ -85,4 +92,4 @@ void TrackingWheelLocalizer::set_pose(Pose pose) {
     }
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
@@ -7,74 +7,93 @@ namespace voss::localizer {
 
 TrackingWheelLocalizerBuilder::TrackingWheelLocalizerBuilder()
     : left_right_dist(0.0), middle_dist(0.0), left_tracking_wheel(nullptr),
-    right_tracking_wheel(nullptr), middle_tracking_wheel(nullptr), imu(nullptr) {
+      right_tracking_wheel(nullptr), middle_tracking_wheel(nullptr),
+      imu(nullptr) {
 }
 
 TrackingWheelLocalizerBuilder TrackingWheelLocalizerBuilder::new_builder() {
     return TrackingWheelLocalizerBuilder();
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_encoder(int adi_port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_left_encoder(int adi_port) {
     left_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_encoder(int smart_port, int adi_port) {
-    left_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_left_encoder(int smart_port, int adi_port) {
+    left_tracking_wheel =
+        std::make_unique<ADITrackingWheel>(smart_port, adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_rotation(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_left_rotation(int port) {
     left_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_motor(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_left_motor(int port) {
     left_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_encoder(int adi_port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_right_encoder(int adi_port) {
     right_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_encoder(int smart_port, int adi_port) {
-    right_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_right_encoder(int smart_port,
+                                                  int adi_port) {
+    right_tracking_wheel =
+        std::make_unique<ADITrackingWheel>(smart_port, adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_rotation(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_right_rotation(int port) {
     right_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_motor(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_right_motor(int port) {
     right_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_encoder(int adi_port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_encoder(int adi_port) {
     middle_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_encoder(int smart_port, int adi_port) {
-    middle_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_encoder(int smart_port,
+                                                   int adi_port) {
+    middle_tracking_wheel =
+        std::make_unique<ADITrackingWheel>(smart_port, adi_port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_rotation(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_rotation(int port) {
     middle_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_motor(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_motor(int port) {
     middle_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_right_tpi(double tpi) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_left_right_tpi(double tpi) {
     if (left_tracking_wheel) {
         left_tracking_wheel->set_tpi(tpi);
     }
@@ -84,28 +103,35 @@ TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_right_tp
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_tpi(double tpi) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_tpi(double tpi) {
     middle_tracking_wheel->set_tpi(tpi);
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_track_width(double track_width) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_track_width(double track_width) {
     left_right_dist = track_width / 2;
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_dist(double middle_dist) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_middle_dist(double middle_dist) {
     this->middle_dist = middle_dist;
     return *this;
 }
 
-TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_imu(int port) {
+TrackingWheelLocalizerBuilder&
+TrackingWheelLocalizerBuilder::with_imu(int port) {
     imu = std::make_unique<pros::IMU>(port);
     return *this;
 }
 
 std::shared_ptr<TrackingWheelLocalizer> TrackingWheelLocalizerBuilder::build() {
-    return std::make_shared<TrackingWheelLocalizer>(std::move(left_tracking_wheel), std::move(right_tracking_wheel), std::move(middle_tracking_wheel), std::move(imu), left_right_dist, middle_dist);
+    return std::make_shared<TrackingWheelLocalizer>(
+        std::move(left_tracking_wheel), std::move(right_tracking_wheel),
+        std::move(middle_tracking_wheel), std::move(imu), left_right_dist,
+        middle_dist);
 }
 
-}
+} // namespace voss::localizer

--- a/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
@@ -75,8 +75,12 @@ TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_motor(
 }
 
 TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_right_tpi(double tpi) {
-    left_tracking_wheel->set_tpi(tpi);
-    right_tracking_wheel->set_tpi(tpi);
+    if (left_tracking_wheel) {
+        left_tracking_wheel->set_tpi(tpi);
+    }
+    if (right_tracking_wheel) {
+        right_tracking_wheel->set_tpi(tpi);
+    }
     return *this;
 }
 

--- a/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizerBuilder.cpp
@@ -1,0 +1,107 @@
+#include "VOSS/localizer/TrackingWheelLocalizerBuilder.hpp"
+#include "VOSS/localizer/ADITrackingWheel.hpp"
+#include "VOSS/localizer/IMETrackingWheel.hpp"
+#include "VOSS/localizer/RotationTrackingWheel.hpp"
+
+namespace voss::localizer {
+
+TrackingWheelLocalizerBuilder::TrackingWheelLocalizerBuilder()
+    : left_right_dist(0.0), middle_dist(0.0), left_tracking_wheel(nullptr),
+    right_tracking_wheel(nullptr), middle_tracking_wheel(nullptr), imu(nullptr) {
+}
+
+TrackingWheelLocalizerBuilder TrackingWheelLocalizerBuilder::new_builder() {
+    return TrackingWheelLocalizerBuilder();
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_encoder(int adi_port) {
+    left_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_encoder(int smart_port, int adi_port) {
+    left_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_rotation(int port) {
+    left_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_motor(int port) {
+    left_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_encoder(int adi_port) {
+    right_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_encoder(int smart_port, int adi_port) {
+    right_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_rotation(int port) {
+    right_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_right_motor(int port) {
+    right_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_encoder(int adi_port) {
+    middle_tracking_wheel = std::make_unique<ADITrackingWheel>(adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_encoder(int smart_port, int adi_port) {
+    middle_tracking_wheel = std::make_unique<ADITrackingWheel>(smart_port, adi_port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_rotation(int port) {
+    middle_tracking_wheel = std::make_unique<RotationTrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_motor(int port) {
+    middle_tracking_wheel = std::make_unique<IMETrackingWheel>(port);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_left_right_tpi(double tpi) {
+    left_tracking_wheel->set_tpi(tpi);
+    right_tracking_wheel->set_tpi(tpi);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_tpi(double tpi) {
+    middle_tracking_wheel->set_tpi(tpi);
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_track_width(double track_width) {
+    left_right_dist = track_width / 2;
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_middle_dist(double middle_dist) {
+    this->middle_dist = middle_dist;
+    return *this;
+}
+
+TrackingWheelLocalizerBuilder& TrackingWheelLocalizerBuilder::with_imu(int port) {
+    imu = std::make_unique<pros::IMU>(port);
+    return *this;
+}
+
+std::shared_ptr<TrackingWheelLocalizer> TrackingWheelLocalizerBuilder::build() {
+    return std::make_shared<TrackingWheelLocalizer>(std::move(left_tracking_wheel), std::move(right_tracking_wheel), std::move(middle_tracking_wheel), std::move(imu), left_right_dist, middle_dist);
+}
+
+}


### PR DESCRIPTION
Add the TrackingWheelLocalizer, which uses the AbstractTrackingWheel class to accept ADI encoders, rotation sensors and IMEs.