### PR TITLE
TrackingWheelLocalizer Improvement

### DIFF
--- a/src/VOSS/localizer/TrackingWheelLocalizer.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizer.cpp
@@ -50,7 +50,9 @@ void TrackingWheelLocalizer::update() {
 
     if (delta_angle) {
         double i = sin(delta_angle / 2.0) * 2.0;
-        if (right_tracking_wheel) {
+        if (left_tracking_wheel && right_tracking_wheel) {
+            local_x = (delta_right + delta_left) / (2 * delta_angle) * i;
+        } else if (right_tracking_wheel) {
             local_x = (delta_right / delta_angle - left_right_dist) * i;
         } else if (left_tracking_wheel) {
             local_x = (delta_left / delta_angle + left_right_dist) * i;


### PR DESCRIPTION
When both left and right tracking wheels are present, we can eliminate using left_right_dist when calculating local_x by averaging the results from using the left and right tracking wheels. This reduces odom drift when turning, especially when using IMEs for tracking.