### PR TITLE
Add constants header

### DIFF
--- a/include/VOSS/constants.hpp
+++ b/include/VOSS/constants.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace voss::constants {
+
+// Time, in milliseconds, between updates of the drive motor powers.
+const unsigned int MOTOR_UPDATE_DELAY = 10;
+
+// Time, in milliseconds, between updates of sensor values.
+const unsigned int SENSOR_UPDATE_DELAY = 10;
+
+}

--- a/include/VOSS/constants.hpp
+++ b/include/VOSS/constants.hpp
@@ -8,4 +8,4 @@ const unsigned int MOTOR_UPDATE_DELAY = 10;
 // Time, in milliseconds, between updates of sensor values.
 const unsigned int SENSOR_UPDATE_DELAY = 10;
 
-}
+} // namespace voss::constants

--- a/src/VOSS/chassis/AbstractChassis.cpp
+++ b/src/VOSS/chassis/AbstractChassis.cpp
@@ -1,6 +1,7 @@
 #include "VOSS/chassis/AbstractChassis.hpp"
 #include "pros/llemu.hpp"
 #include "pros/rtos.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/exit_conditions/AbstractExitCondition.hpp"
 
 #include <cmath>
@@ -28,7 +29,7 @@ void AbstractChassis::move_task(controller_ptr controller, ec_ptr ec,
                     return;
                 }
 
-                pros::delay(10);
+                pros::delay(constants::MOTOR_UPDATE_DELAY);
             }
             this->task_running = false;
         });
@@ -58,7 +59,7 @@ void AbstractChassis::turn_task(controller_ptr controller, ec_ptr ec,
                     return;
                 }
 
-                pros::delay(10);
+                pros::delay(constants::MOTOR_UPDATE_DELAY);
             }
             this->task_running = false;
         });
@@ -99,7 +100,7 @@ void AbstractChassis::move(Pose target, controller_ptr controller, double max,
 void AbstractChassis::move(Pose target, controller_ptr controller, ec_ptr ec,
                            double max, voss::Flags flags) {
     while (this->task_running) {
-        pros::delay(10);
+        pros::delay(constants::MOTOR_UPDATE_DELAY);
     }
     this->task_running = true;
     controller->set_target(target, flags & voss::Flags::RELATIVE, ec);
@@ -124,7 +125,7 @@ void AbstractChassis::turn(double target, controller_ptr controller, ec_ptr ec,
                            double max, voss::Flags flags,
                            voss::AngularDirection direction) {
     while (this->task_running) {
-        pros::delay(10);
+        pros::delay(constants::MOTOR_UPDATE_DELAY);
     }
     this->task_running = true;
 

--- a/src/VOSS/controller/BoomerangController.cpp
+++ b/src/VOSS/controller/BoomerangController.cpp
@@ -128,7 +128,6 @@ BoomerangController::modify_angular_constants(double kP, double kI, double kD) {
     return this->p;
 }
 
-
 std::shared_ptr<BoomerangController>
 BoomerangController::modify_min_error(double min_error) {
     auto pid_mod = BoomerangControllerBuilder::from(*this)

--- a/src/VOSS/controller/BoomerangControllerBuilder.cpp
+++ b/src/VOSS/controller/BoomerangControllerBuilder.cpp
@@ -46,7 +46,6 @@ BoomerangControllerBuilder::with_min_error(double error) {
     return *this;
 }
 
-
 BoomerangControllerBuilder&
 BoomerangControllerBuilder::with_lead_pct(double lead_pct) {
     this->ctrl.lead_pct = lead_pct;

--- a/src/VOSS/controller/PIDControllerBuilder.cpp
+++ b/src/VOSS/controller/PIDControllerBuilder.cpp
@@ -38,7 +38,6 @@ PIDControllerBuilder::with_angular_constants(double kP, double kI, double kD) {
     return *this;
 }
 
-
 PIDControllerBuilder& PIDControllerBuilder::with_min_error(double error) {
     this->ctrl.min_error = error;
     return *this;

--- a/src/VOSS/exit_conditions/SettleExitCondition.cpp
+++ b/src/VOSS/exit_conditions/SettleExitCondition.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/exit_conditions/SettleExitCondition.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/exit_conditions/AbstractExitCondition.hpp"
 #include "VOSS/utils/angle.hpp"
 #include "VOSS/utils/Pose.hpp"
@@ -9,7 +10,7 @@ namespace voss::controller {
 bool SettleExitCondition::is_met(Pose current_pose, bool thru) {
     printf("initial %d current %d\n", initial_time, current_time);
     if (initial_time <= initial_delay) {
-        initial_time += 10;
+        initial_time += constants::MOTOR_UPDATE_DELAY;
         return false;
     }
     if (this->current_time < this->settle_time) {
@@ -19,7 +20,7 @@ bool SettleExitCondition::is_met(Pose current_pose, bool thru) {
                 if (std::abs(current_pose.theta.value() -
                              this->prev_pose.theta.value()) <
                     voss::to_radians(this->tolerance)) {
-                    this->current_time += 10;
+                    this->current_time += constants::MOTOR_UPDATE_DELAY;
                 } else {
                     current_time = 0;
                     prev_pose = current_pose;

--- a/src/VOSS/exit_conditions/TimeOutExitCondition.cpp
+++ b/src/VOSS/exit_conditions/TimeOutExitCondition.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/exit_conditions/TimeOutExitCondition.hpp"
+#include "VOSS/constants.hpp"
 #include <cstdio>
 
 namespace voss::controller {
@@ -8,7 +9,7 @@ TimeOutExitCondition::TimeOutExitCondition(int timeout) : timeout(timeout) {
 }
 
 bool TimeOutExitCondition::is_met(Pose current_pose, bool thru) {
-    this->current_time += 10;
+    this->current_time += constants::MOTOR_UPDATE_DELAY;
     // if (this->current_time >= this->timeout)
     //     printf("Time out cond met\n");
     return this->current_time >= this->timeout;

--- a/src/VOSS/exit_conditions/ToleranceAngularExitCondition.cpp
+++ b/src/VOSS/exit_conditions/ToleranceAngularExitCondition.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/exit_conditions/ToleranceAngularExitCondition.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/utils/angle.hpp"
 #include <cmath>
 #include <cstdio>
@@ -17,7 +18,7 @@ bool ToleranceAngularExitCondition::is_met(Pose current_pose, bool thru) {
         if (thru) {
             return true;
         }
-        current_time += 10;
+        current_time += constants::MOTOR_UPDATE_DELAY;
     } else {
         current_time = 0;
     }

--- a/src/VOSS/exit_conditions/ToleranceLinearExitCondition.cpp
+++ b/src/VOSS/exit_conditions/ToleranceLinearExitCondition.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/exit_conditions/ToleranceLinearExitCondition.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/utils/Point.hpp"
 #include <cmath>
 #include <cstdio>
@@ -20,7 +21,7 @@ bool ToleranceLinearExitCondition::is_met(Pose current_pose, bool thru) {
         if (thru) {
             return true;
         }
-        current_time += 10;
+        current_time += constants::MOTOR_UPDATE_DELAY;
     } else {
         current_time = 0;
     }

--- a/src/VOSS/localizer/ADILocalizer.cpp
+++ b/src/VOSS/localizer/ADILocalizer.cpp
@@ -1,6 +1,7 @@
 #include "VOSS/localizer/ADILocalizer.hpp"
 #include "ADILocalizer.hpp"
 #include "pros/adi.hpp"
+#include "VOSS/constants.hpp"
 
 #include <cmath>
 #include <memory>
@@ -83,7 +84,7 @@ void ADILocalizer::calibrate() {
     if (imu) {
         this->imu->reset();
         while (this->imu->is_calibrating()) {
-            pros::delay(10);
+            pros::delay(constants::SENSOR_UPDATE_DELAY);
         }
     }
     this->pose = voss::AtomicPose{0.0, 0.0, 0.0};

--- a/src/VOSS/localizer/AbstractLocalizer.cpp
+++ b/src/VOSS/localizer/AbstractLocalizer.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/localizer/AbstractLocalizer.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/utils/angle.hpp"
 #include <cmath>
 
@@ -21,7 +22,7 @@ void AbstractLocalizer::begin_localization() {
             this->update();
             lock.unlock();
 
-            pros::delay(10);
+            pros::delay(constants::SENSOR_UPDATE_DELAY);
         }
     });
 }

--- a/src/VOSS/localizer/IMELocalizer.cpp
+++ b/src/VOSS/localizer/IMELocalizer.cpp
@@ -4,6 +4,7 @@
 #include "pros/adi.h"
 #include "pros/adi.hpp"
 #include "pros/motor_group.hpp"
+#include "VOSS/constants.hpp"
 
 #include <cmath>
 #include <memory>
@@ -83,7 +84,7 @@ void IMELocalizer::calibrate() {
     if (imu) {
         this->imu->reset();
         while (imu->is_calibrating()) {
-            pros::delay(10);
+            pros::delay(constants::SENSOR_UPDATE_DELAY);
         }
     }
     if (left_motors) {

--- a/src/VOSS/localizer/TrackingWheelLocalizer.cpp
+++ b/src/VOSS/localizer/TrackingWheelLocalizer.cpp
@@ -1,4 +1,5 @@
 #include "VOSS/localizer/TrackingWheelLocalizer.hpp"
+#include "VOSS/constants.hpp"
 #include "VOSS/utils/angle.hpp"
 
 namespace voss::localizer {
@@ -82,6 +83,9 @@ void TrackingWheelLocalizer::calibrate() {
     }
     if (imu) {
         imu->reset(true);
+        while (imu->is_calibrating()) {
+            pros::delay(constants::SENSOR_UPDATE_DELAY);
+        }
     }
     this->pose = AtomicPose{0.0, 0.0, 0.0};
 }


### PR DESCRIPTION
Create a constants header file where the loop delays for motor and sensor updates is defined. Using the constants gets rid of the magic numbers in the code when calling pros::delay.