### PR TITLE
Limit lin_speed, scale ang_speed in PIDController and BoomerangController

### DIFF
--- a/src/VOSS/controller/BoomerangController.cpp
+++ b/src/VOSS/controller/BoomerangController.cpp
@@ -38,7 +38,6 @@ BoomerangController::get_command(bool reverse, bool thru,
     double current_angle =
         this->l->get_orientation_rad() + (reverse ? M_PI : 0);
     bool chainedExecutable = false;
-    bool noPose = !this->target.theta.has_value();
     double angle_error;
     angle_error = atan2(dy, dx) - current_angle;
 
@@ -50,24 +49,18 @@ BoomerangController::get_command(bool reverse, bool thru,
     }
     lin_speed *= dir;
 
+    double pose_error = voss::norm_delta(target.theta.value() - current_angle);
+
     double ang_speed;
     if (distance_error < min_error) {
         this->can_reverse = true;
 
-        if (noPose) {
-            ang_speed = 0; // disable turning when close to the point to prevent
-                           // spinning
-        } else {
-            // turn to face the finale pose angle if executing a pose movement
-            double poseError = target.theta.value() - current_angle;
+        ang_speed = angular_pid.update(pose_error);
+    } else if (distance_error < 2 * min_error) {
+        double scale_factor = (distance_error - min_error) / min_error;
+        double scaled_angle_error = voss::norm_delta(scale_factor * angle_error + (1 - scale_factor) * pose_error);
 
-            while (fabs(poseError) > M_PI)
-                poseError -= 2 * M_PI * poseError / fabs(poseError);
-            ang_speed = angular_pid.update(poseError);
-        }
-
-        // reduce the linear speed if the bot is tangent to the target
-
+        ang_speed = angular_pid.update(scaled_angle_error);
     } else {
         if (fabs(angle_error) > M_PI_2 && this->can_reverse) {
             angle_error =
@@ -79,6 +72,8 @@ BoomerangController::get_command(bool reverse, bool thru,
     }
 
     lin_speed *= cos(angle_error);
+
+    lin_speed = std::max(-100.0, std::min(100.0, lin_speed));
 
     if (ec->is_met(this->l->get_pose(), thru)) {
         if (thru) {

--- a/src/VOSS/controller/BoomerangController.cpp
+++ b/src/VOSS/controller/BoomerangController.cpp
@@ -58,7 +58,8 @@ BoomerangController::get_command(bool reverse, bool thru,
         ang_speed = angular_pid.update(pose_error);
     } else if (distance_error < 2 * min_error) {
         double scale_factor = (distance_error - min_error) / min_error;
-        double scaled_angle_error = voss::norm_delta(scale_factor * angle_error + (1 - scale_factor) * pose_error);
+        double scaled_angle_error = voss::norm_delta(
+            scale_factor * angle_error + (1 - scale_factor) * pose_error);
 
         ang_speed = angular_pid.update(scaled_angle_error);
     } else {

--- a/src/VOSS/controller/PIDController.cpp
+++ b/src/VOSS/controller/PIDController.cpp
@@ -64,6 +64,10 @@ PIDController::get_command(bool reverse, bool thru,
         // reduce the linear speed if the bot is tangent to the target
         lin_speed *= cos(angle_error);
 
+    } else if (distance_error < 2 * min_error) {
+        // scale angular speed down to 0 as distance_error approaches min_error
+        ang_speed = angular_pid.update(angle_error);
+        ang_speed *= (distance_error - min_error) / min_error;
     } else {
         if (fabs(angle_error) > M_PI_2 && this->can_reverse) {
             angle_error =
@@ -73,6 +77,7 @@ PIDController::get_command(bool reverse, bool thru,
 
         ang_speed = angular_pid.update(angle_error);
     }
+    lin_speed = std::max(-100.0, std::min(100.0, lin_speed));
     // Runs at the end of a through movement
     if (ec->is_met(this->l->get_pose(), thru)) {
         if (thru) {


### PR DESCRIPTION
Limit lin_speed in PIDController and Boomerang controller so it scales better in DiffChassis
Scale ang_speed for a smoother transition between being outside of min_error and being within min_error.