### PR TITLE
fix boomerang

### DIFF
--- a/src/VOSS/controller/BoomerangController.cpp
+++ b/src/VOSS/controller/BoomerangController.cpp
@@ -28,16 +28,22 @@ BoomerangController::get_command(bool reverse, bool thru,
     double dy = target.y - current_pos.y;
 
     double distance_error = sqrt(dx * dx + dy * dy);
-    double at = voss::to_radians(target.theta.value());
+    double at = target.theta.value();
 
     this->carrotPoint = {this->target.x - distance_error * cos(at) * lead_pct,
                          this->target.y - distance_error * sin(at) * lead_pct,
                          target.theta};
+    dx = carrotPoint.x - current_pos.x;
+    dy = carrotPoint.y - current_pos.y;
     double current_angle =
-        this->l->get_orientation_rad() + (reverse ? M_PI : 0);
+        this->l->get_orientation_rad();
 
     double angle_error;
-    angle_error = atan2(dy, dx) - current_angle;
+    if (!reverse) {
+        angle_error = atan2(dy, dx) - current_angle;
+    } else {
+        angle_error = atan2(-dy, -dx) - current_angle;
+    }
 
     angle_error = voss::norm_delta(angle_error);
 

--- a/src/VOSS/controller/BoomerangController.cpp
+++ b/src/VOSS/controller/BoomerangController.cpp
@@ -35,8 +35,7 @@ BoomerangController::get_command(bool reverse, bool thru,
                          target.theta};
     dx = carrotPoint.x - current_pos.x;
     dy = carrotPoint.y - current_pos.y;
-    double current_angle =
-        this->l->get_orientation_rad();
+    double current_angle = this->l->get_orientation_rad();
 
     double angle_error;
     if (!reverse) {


### PR DESCRIPTION
Change BoomerangController so that it:
1. Actually uses the carrot point
2. No longer requires you to flip the target angle by 180 degrees when going in reverse